### PR TITLE
Add -mfpu=neon-vfpv4 if cpu is krait

### DIFF
--- a/core/clang/arm.mk
+++ b/core/clang/arm.mk
@@ -7,7 +7,7 @@ CLANG_CONFIG_arm_EXTRA_CFLAGS :=
 ifneq (,$(filter krait,$(TARGET_$(combo_2nd_arch_prefix)CPU_VARIANT)))
   # Android's clang support's krait as a CPU whereas GCC doesn't. Specify
   # -mcpu here rather than the more normal core/combo/arch/arm/armv7-a-neon.mk.
-  CLANG_CONFIG_arm_EXTRA_CFLAGS += -mcpu=krait
+  CLANG_CONFIG_arm_EXTRA_CFLAGS += -mcpu=krait -mfpu=neon-vfpv4
 endif
 
 ifeq ($(HOST_OS),darwin)


### PR DESCRIPTION
Upstream clang r239152 (http://reviews.llvm.org/D10239) caused a pretty
significant change in behavior.  Passing an FPU feature via -mfpu
disables any feature not supported by those flags (in addition to the
old behavior of enabling features supported by the flags).  For e.g.,
-mfpu=neon used to just pass +neon, +vfp3 as target features to the
backend.  Now, -mfpu=neon also passes -vfp4, -fp16, -fp-armv8.

The backend has always disabled implied feature bits if a feature is
disabled.  Upon seeing the target feature -vfp4, it will disable any
processor/feature that implies vfp4, including the bit that the
processor is a Krait.  Since Krait has both Neon and vfp4, it is safe to
pass '-mfpu=neon-vfpv4'.

Change-Id: Ibbb992e80b8cbc8dc36d5df556885d0912baea22