### PR TITLE
gdbclient: fix build output directory path

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1261,7 +1261,7 @@ function gdbclient() {
     ROOT=`realpath .`
   fi
 
-  local OUT_ROOT="$ROOT/out/target/product/$DEVICE"
+  local OUT_ROOT="$ANDROID_PRODUCT_OUT"
   local SYMBOLS_DIR="$OUT_ROOT/symbols"
 
   if [ ! -d $SYMBOLS_DIR ]; then


### PR DESCRIPTION
adb_get_product_device returns the marketing name of the device
instead of the name used in the build tree resulting in an invalid
OUT_ROOT directory path.

Just use the already defined $ANDROID_PRODUCT_OUT as OUT_ROOT.

Change-Id: I5ad5907a0d629613b0b33aec9c465a1fc5aacd61