### PR TITLE
Permit redirection of vendor to system

### DIFF
--- a/core/envsetup.mk
+++ b/core/envsetup.mk
@@ -178,8 +178,8 @@ board_config_mk :=
 # Now we can substitute with the real value of TARGET_COPY_OUT_VENDOR
 ifeq ($(TARGET_COPY_OUT_VENDOR),$(_vendor_path_placeholder))
 TARGET_COPY_OUT_VENDOR := system/vendor
-else ifeq ($(filter vendor system/vendor,$(TARGET_COPY_OUT_VENDOR)),)
-$(error TARGET_COPY_OUT_VENDOR must be either 'vendor' or 'system/vendor', seeing '$(TARGET_COPY_OUT_VENDOR)'.)
+else ifeq ($(filter vendor system/vendor system,$(TARGET_COPY_OUT_VENDOR)),)
+$(error TARGET_COPY_OUT_VENDOR must be either 'vendor', 'system/vendor' or 'system', seeing '$(TARGET_COPY_OUT_VENDOR)'.)
 endif
 PRODUCT_COPY_FILES := $(subst $(_vendor_path_placeholder),$(TARGET_COPY_OUT_VENDOR),$(PRODUCT_COPY_FILES))
 ###########################################


### PR DESCRIPTION
For devices where /system/vendor needs to be a symlink to /vendor.

This allows a target to set TARGET_COPY_OUT_VENDOR := system in
order to force modules that want to be placed in vendor to instead
be redirected into /system.
eg angler

Change-Id: I4bffcefcda0b33dc5350b1702ec6d0166b18d775